### PR TITLE
Refactor RuntimeException imports and fix namespace typo

### DIFF
--- a/src/AIQueryAdvisor.php
+++ b/src/AIQueryAdvisor.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Koriym\SqlQuality;
 
+use Koriym\SqlQuality\Exception\RuntimeException;
 use PDO;
-use RuntimeException;
 
 use function array_filter;
 use function array_map;

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Koriym\SqlQaulity\Exception;
+namespace Koriym\SqlQuality\Exception;
 
 class LogicException extends \LogicException
 {

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Koriym\SqlQaulity\Exception;
+namespace Koriym\SqlQuality\Exception;
 
 class RuntimeException extends \RuntimeException
 {

--- a/src/ExplainParser.php
+++ b/src/ExplainParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\SqlQuality;
 
-use RuntimeException;
+use Koriym\SqlQuality\Exception\RuntimeException;
 
 use function array_filter;
 use function array_merge;

--- a/src/MarkdownSummaryReportGenerator.php
+++ b/src/MarkdownSummaryReportGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\SqlQuality;
 
-use RuntimeException;
+use Koriym\SqlQuality\Exception\RuntimeException;
 
 use function array_column;
 use function count;

--- a/src/SqlFileAnalyzer.php
+++ b/src/SqlFileAnalyzer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Koriym\SqlQuality;
 
+use Koriym\SqlQuality\Exception\RuntimeException;
 use PDO;
-use RuntimeException;
 
 use function array_keys;
 use function array_map;


### PR DESCRIPTION
---

**Description:**

- Refactored RuntimeException imports to use project-specific namespace for consistency.
- Fixed namespace typo from "SqlQaulity" to "SqlQuality" in exception classes for correct autoloading.

---

## Sourceryによる概要

RuntimeExceptionのインポートをプロジェクト固有の名前空間を使用するようにリファクタリングし、例外クラスの名前空間のタイプミスを修正します。

バグ修正:
- 例外クラスでの名前空間のタイプミスを 'SqlQaulity' から 'SqlQuality' に修正し、正しいオートローディングを実現。

機能強化:
- 一貫性を持たせるために、RuntimeExceptionのインポートをプロジェクト固有の名前空間を使用するようにリファクタリング。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor RuntimeException imports to use the project-specific namespace and fix a namespace typo in exception classes.

Bug Fixes:
- Fix namespace typo from 'SqlQaulity' to 'SqlQuality' in exception classes for correct autoloading.

Enhancements:
- Refactor RuntimeException imports to use the project-specific namespace for consistency.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling consistency to ensure more reliable exception management during runtime.
- **Refactor**
	- Aligned internal exception references for enhanced system robustness without altering overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->