### PR TITLE
Support for simply "GROUP BY" case

### DIFF
--- a/demo/build/sql-quality/24_grouping_operation.md
+++ b/demo/build/sql-quality/24_grouping_operation.md
@@ -1,0 +1,55 @@
+# SQL Performance Analysis
+- **SQL File:** `24_grouping_operation.sql`
+- **Cost:** 1.86
+
+## SQL
+```sql
+-- 19_grouping_operation.sql
+SELECT
+  post_id
+FROM
+  comments
+WHERE
+  post_id IN (:post_ids)
+GROUP BY
+  post_id
+HAVING
+  count(*) = :target_count
+
+```
+
+## Detected Issues
+
+
+## Explain Tree
+```
+Grouping Operation
++- Table scan
+   +- Table
+      table           comments
+      rows            8
+      filtered        100.00
+      condition       (`test`.`comments`.`post_id` in (375,376,377,388,389,390))
+```
+## Analysis Detail
+
+### Schema
+{"comments":{"columns":[{"COLUMN_NAME":"id","DATA_TYPE":"int","COLUMN_TYPE":"int","IS_NULLABLE":"NO","COLUMN_KEY":"PRI","COLUMN_DEFAULT":null,"EXTRA":""},{"COLUMN_NAME":"post_id","DATA_TYPE":"int","COLUMN_TYPE":"int","IS_NULLABLE":"YES","COLUMN_KEY":"MUL","COLUMN_DEFAULT":null,"EXTRA":""},{"COLUMN_NAME":"user_id","DATA_TYPE":"int","COLUMN_TYPE":"int","IS_NULLABLE":"YES","COLUMN_KEY":"MUL","COLUMN_DEFAULT":null,"EXTRA":""},{"COLUMN_NAME":"content","DATA_TYPE":"text","COLUMN_TYPE":"text","IS_NULLABLE":"YES","COLUMN_KEY":"","COLUMN_DEFAULT":null,"EXTRA":""},{"COLUMN_NAME":"status","DATA_TYPE":"varchar","COLUMN_TYPE":"varchar(20)","IS_NULLABLE":"YES","COLUMN_KEY":"","COLUMN_DEFAULT":"pending","EXTRA":""},{"COLUMN_NAME":"created_at","DATA_TYPE":"datetime","COLUMN_TYPE":"datetime","IS_NULLABLE":"YES","COLUMN_KEY":"","COLUMN_DEFAULT":"CURRENT_TIMESTAMP","EXTRA":"DEFAULT_GENERATED"}],"indexes":[{"INDEX_NAME":"idx_comments_post_created","COLUMN_NAME":"post_id","NON_UNIQUE":1,"SEQ_IN_INDEX":1,"CARDINALITY":4318},{"INDEX_NAME":"idx_comments_post_created","COLUMN_NAME":"created_at","NON_UNIQUE":1,"SEQ_IN_INDEX":2,"CARDINALITY":9995},{"INDEX_NAME":"idx_comments_post_id","COLUMN_NAME":"post_id","NON_UNIQUE":1,"SEQ_IN_INDEX":1,"CARDINALITY":4318},{"INDEX_NAME":"PRIMARY","COLUMN_NAME":"id","NON_UNIQUE":0,"SEQ_IN_INDEX":1,"CARDINALITY":10023},{"INDEX_NAME":"user_id","COLUMN_NAME":"user_id","NON_UNIQUE":1,"SEQ_IN_INDEX":1,"CARDINALITY":1000}],"status":{"table_rows":10023,"data_length":1589248,"index_length":835584,"auto_increment":null,"create_time":"2025-02-13 10:11:38","update_time":"2025-02-13 10:11:46"}}}
+
+### EXPLAIN JSON
+{"select_id":1,"cost_info":{"query_cost":"1.86"},"grouping_operation":{"using_filesort":false,"table":{"table_name":"comments","access_type":"range","possible_keys":["idx_comments_post_id","idx_comments_post_created"],"key":"idx_comments_post_id","used_key_parts":["post_id"],"key_length":"5","rows_examined_per_scan":8,"rows_produced_per_join":8,"filtered":"100.00","using_index":true,"cost_info":{"read_cost":"1.06","eval_cost":"0.80","prefix_cost":"1.86","data_read_per_join":"896"},"used_columns":["id","post_id"],"attached_condition":"(`test`.`comments`.`post_id` in (375,376,377,388,389,390))"}}}
+
+### EXPLAIN ANALYZE
+-> Filter: (count(0) = 2)  (actual time=0.019..0.019 rows=0 loops=1)
+    -> Group aggregate: count(0)  (actual time=0.009..0.018 rows=6 loops=1)
+        -> Filter: (comments.post_id in (375,376,377,388,389,390))  (cost=1.86 rows=8) (actual time=0.006..0.016 rows=8 loops=1)
+            -> Index range scan on comments using idx_comments_post_id  (cost=1.86 rows=8) (actual time=0.005..0.014 rows=8 loops=1)
+
+### SHOW WARNINGS
+N/A
+
+## Analysis Instructions
+Create a SQL performance analysis report for this query. Begin with a table of key metrics showing current values and their impact. Then describe the detected issues, focusing on the root causes. Follow with specific improvement recommendations, including SQL examples and their expected impact. End with implementation priorities and any important considerations. Keep the analysis focused on actionable insights that will lead to significant performance gains.
+
+
+以上の分析を日本語で記述してください。

--- a/demo/build/sql-quality/24_grouping_operation.md
+++ b/demo/build/sql-quality/24_grouping_operation.md
@@ -4,7 +4,7 @@
 
 ## SQL
 ```sql
--- 19_grouping_operation.sql
+-- 24_grouping_operation.sql
 SELECT
   post_id
 FROM
@@ -42,7 +42,7 @@ Grouping Operation
 ### EXPLAIN ANALYZE
 -> Filter: (count(0) = 2)  (actual time=0.019..0.019 rows=0 loops=1)
     -> Group aggregate: count(0)  (actual time=0.009..0.018 rows=6 loops=1)
-        -> Filter: (comments.post_id in (375,376,377,388,389,390))  (cost=1.86 rows=8) (actual time=0.006..0.016 rows=8 loops=1)
+        -> Filter: (comments.post_id in (375,376,377,388,389,390))  (cost=1.86 rows=8) (actual time=0.006..0.015 rows=8 loops=1)
             -> Index range scan on comments using idx_comments_post_id  (cost=1.86 rows=8) (actual time=0.005..0.014 rows=8 loops=1)
 
 ### SHOW WARNINGS

--- a/demo/build/sql-quality/summary_report.md
+++ b/demo/build/sql-quality/summary_report.md
@@ -4,35 +4,36 @@
 
 | SQL File | Cost | Exec Time (ms) | Level | Issues | Report |
 |----------|------|----------------|-------|---------|--------|
-| 1\_full\_table\_scan.sql | 497.95 | 6.14 | Medium (μ ± σ) | FullTableScan | [Details](1\_full\_table\_scan.md) |
-| 2\_filesort.sql | 269.55 | 0.08 | Medium (μ ± σ) | IneffectiveSort | [Details](2\_filesort.md) |
-| 3\_function\_on\_indexed\_column.sql | 497.95 | 1.47 | Medium (μ ± σ) | FunctionInvalidatesIndex, FullTableScan | [Details](3\_function\_on\_indexed\_column.md) |
-| 4\_no\_index\_on\_join.sql | 1462.81 | 12.21 | Medium (μ ± σ) | IneffectiveJoin, TemporaryTableGrouping | [Details](4\_no\_index\_on\_join.md) |
-| 5\_multiple\_wildcard\_like.sql | 497.95 | 1.90 | Medium (μ ± σ) | FullTableScan, IneffectiveLikePattern | [Details](5\_multiple\_wildcard\_like.md) |
-| 6\_implicit\_type\_conversion.sql | 202.50 | 0.64 | Medium (μ ± σ) | FullTableScan, ImplicitTypeConversion | [Details](6\_implicit\_type\_conversion.md) |
-| 7\_temporary\_table\_grouping.sql | 202.50 | 0.60 | Medium (μ ± σ) | TemporaryTableGrouping | [Details](7\_temporary\_table\_grouping.md) |
-| 8\_suboptimal\_or\_condition.sql | 497.95 | 3.39 | Medium (μ ± σ) | FullTableScan, ImplicitTypeConversion | [Details](8\_suboptimal\_or\_condition.md) |
-| 9\_inefficient\_in\_query.sql | 3447.95 | 5.12 | ⚠️⚠️Very High (> μ + 2σ) | FullTableScan, IneffectiveRangeScan, IneffectiveSort | [Details](9\_inefficient\_in\_query.md) |
-| 10\_redundant\_join.sql | 85.25 | 2.48 | Medium (μ ± σ) | - | [Details](10\_redundant\_join.md) |
-| 11\_nested\_loop.sql | 274.18 | 0.19 | Medium (μ ± σ) | FullTableScan | [Details](11\_nested\_loop.md) |
-| 12\_select1.sql | 1.00 | 0.05 | Medium (μ ± σ) | - | [Details](12\_select1.md) |
-| 15\_listed\_parameters.sql | 101.75 | 0.29 | Medium (μ ± σ) | FullTableScan, IneffectiveRangeScan | [Details](15\_listed\_parameters.md) |
-| 16\_ineffective\_range\_scan.sql | 424.70 | 1.31 | Medium (μ ± σ) | FullTableScan, IneffectiveSort | [Details](16\_ineffective\_range\_scan.md) |
-| 18\_select\_distinct.sql | 1.86 | 0.09 | Medium (μ ± σ) | TemporaryTableGrouping | [Details](18\_select\_distinct.md) |
-| 19\_unnecessary\_distinct.sql | 0.35 | 0.05 | Medium (μ ± σ) | - | [Details](19\_unnecessary\_distinct.md) |
-| 20\_multi\_table\_update.sql | 2252.33 | 2.49 | ⚠️High (μ + σ to μ + 2σ) | - | [Details](20\_multi\_table\_update.md) |
-| 21\_low\_cardinality\_index.sql | 85.25 | 0.89 | Medium (μ ± σ) | - | [Details](21\_low\_cardinality\_index.md) |
+| 1\_full\_table\_scan.sql | 503.85 | 7.28 | Medium (μ ± σ) | FullTableScan | [Details](1\_full\_table\_scan.md) |
+| 2\_filesort.sql | 272.55 | 0.19 | Medium (μ ± σ) | IneffectiveSort | [Details](2\_filesort.md) |
+| 3\_function\_on\_indexed\_column.sql | 503.85 | 2.99 | Medium (μ ± σ) | FunctionInvalidatesIndex, FullTableScan | [Details](3\_function\_on\_indexed\_column.md) |
+| 4\_no\_index\_on\_join.sql | 1468.14 | 31.90 | ⚠️High (μ + σ to μ + 2σ) | IneffectiveJoin, TemporaryTableGrouping | [Details](4\_no\_index\_on\_join.md) |
+| 5\_multiple\_wildcard\_like.sql | 503.85 | 5.17 | Medium (μ ± σ) | FullTableScan, IneffectiveLikePattern | [Details](5\_multiple\_wildcard\_like.md) |
+| 6\_implicit\_type\_conversion.sql | 202.50 | 1.47 | Medium (μ ± σ) | FullTableScan, ImplicitTypeConversion | [Details](6\_implicit\_type\_conversion.md) |
+| 7\_temporary\_table\_grouping.sql | 202.50 | 1.06 | Medium (μ ± σ) | TemporaryTableGrouping | [Details](7\_temporary\_table\_grouping.md) |
+| 8\_suboptimal\_or\_condition.sql | 503.85 | 6.99 | Medium (μ ± σ) | FullTableScan, ImplicitTypeConversion | [Details](8\_suboptimal\_or\_condition.md) |
+| 9\_inefficient\_in\_query.sql | 3483.85 | 12.53 | ⚠️⚠️Very High (> μ + 2σ) | FullTableScan, IneffectiveRangeScan, IneffectiveSort | [Details](9\_inefficient\_in\_query.md) |
+| 10\_redundant\_join.sql | 85.25 | 6.64 | Medium (μ ± σ) | - | [Details](10\_redundant\_join.md) |
+| 11\_nested\_loop.sql | 276.61 | 0.38 | Medium (μ ± σ) | FullTableScan | [Details](11\_nested\_loop.md) |
+| 12\_select1.sql | 1.00 | 0.08 | Medium (μ ± σ) | - | [Details](12\_select1.md) |
+| 15\_listed\_parameters.sql | 101.75 | 0.49 | Medium (μ ± σ) | FullTableScan, IneffectiveRangeScan | [Details](15\_listed\_parameters.md) |
+| 16\_ineffective\_range\_scan.sql | 424.70 | 3.04 | Medium (μ ± σ) | FullTableScan, IneffectiveSort | [Details](16\_ineffective\_range\_scan.md) |
+| 18\_select\_distinct.sql | 1.86 | 0.16 | Medium (μ ± σ) | TemporaryTableGrouping | [Details](18\_select\_distinct.md) |
+| 19\_unnecessary\_distinct.sql | 0.35 | 0.14 | Medium (μ ± σ) | - | [Details](19\_unnecessary\_distinct.md) |
+| 20\_multi\_table\_update.sql | 2195.78 | 8.93 | ⚠️High (μ + σ to μ + 2σ) | - | [Details](20\_multi\_table\_update.md) |
+| 21\_low\_cardinality\_index.sql | 85.25 | 1.48 | Medium (μ ± σ) | - | [Details](21\_low\_cardinality\_index.md) |
+| 24\_grouping\_operation.sql | 1.86 | 0.18 | Medium (μ ± σ) | - | [Details](24\_grouping\_operation.md) |
 
 ## Queries with Optimizer Impact
 
 | SQL File | Base Access | Optimized Access | Cost Impact | Base Issues | Plan Changes |
 |:----------|:------------|:----------------|:------------|:------------|:-------------|
-| 11\_nested\_loop.sql | ALL, 4897 rows, 100.0% | ALL, 1000 rows, 10.0% → ref, using idx\_posts\_user\_id, 4 rows, 100.0% | -44.9% | FullTableScan | - |
+| 11\_nested\_loop.sql | ALL, 4956 rows, 100.0% | ALL, 1000 rows, 10.0% → ref, using idx\_posts\_user\_id, 4 rows, 100.0% | -45.1% | FullTableScan | - |
 | 16\_ineffective\_range\_scan.sql | ALL, 2000 rows, 100.0% | ALL, 2000 rows, 11.1% | -80.7% | FullTableScan, IneffectiveSort | Filtering: 100.0% → 11.1%, Cost(R/E): 2.5/200.0 → 180.3/22.2 |
 
 ## Statistics
 
-- Total queries analyzed: 18
-- Average query cost: 600.21
-- Standard deviation: 883.29
+- Total queries analyzed: 19
+- Average query cost: 569.44
+- Standard deviation: 870.77
 

--- a/src/ExplainParser.php
+++ b/src/ExplainParser.php
@@ -71,6 +71,16 @@ class ExplainParser
             return $this->parseNestedLoop($nestedLoop);
         }
 
+        if (isset($queryBlock['grouping_operation']['table'])) {
+            $tableNode = $this->parseSingleTable($queryBlock['grouping_operation']['table']);
+
+            return new TreeNode(
+                'Grouping Operation',
+                [],
+                [$tableNode],
+            );
+        }
+
         // 3) nested_loop が query_block 直下にある場合のチェック
         if (isset($queryBlock['nested_loop'])) {
             /** @var array<array{table: ExplainTable}> $nestedLoop */

--- a/tests/params/sql_params.php
+++ b/tests/params/sql_params.php
@@ -36,4 +36,8 @@ return [
     '19_unnecessary_distinct.sql' => ['user_id' => 1],
     '20_multi_table_update.sql' => [],
     '21_low_cardinality_index.sql' => ['status' => 'active'],
+    '24_grouping_operation.sql' => [
+        'post_ids' => [375, 376, 377, 388, 389, 390],
+        'target_count' => 2,
+    ],
 ];

--- a/tests/sql/24_grouping_operation.sql
+++ b/tests/sql/24_grouping_operation.sql
@@ -1,4 +1,4 @@
--- 19_grouping_operation.sql
+-- 24_grouping_operation.sql
 SELECT
   post_id
 FROM

--- a/tests/sql/24_grouping_operation.sql
+++ b/tests/sql/24_grouping_operation.sql
@@ -1,0 +1,11 @@
+-- 19_grouping_operation.sql
+SELECT
+  post_id
+FROM
+  comments
+WHERE
+  post_id IN (:post_ids)
+GROUP BY
+  post_id
+HAVING
+  count(*) = :target_count


### PR DESCRIPTION
※ #14 の再作成版です

Description:
* Explain parser が シンプルな GROUP BY ケースに対応 (grouping_operation) できていなかったので拾うようにしました。
  * JOINおよびORDER BYとの組み合わせる GROUP BY の場合、別のblock処理でパースされる流れなので問題にはなっていませんでした。
* grouping_optrationのブロック構造は先日の duplicates_removal ケースとそっくりだったため、パース処理も同様のものとしました。

## Sourceryによるサマリー

新機能:
- 簡単な "GROUP BY" ステートメントの解析をサポートします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support parsing of simple "GROUP BY" statements.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive SQL performance analysis report for `24_grouping_operation.sql`, including cost estimates and execution details.
  - Enhanced the performance summary with updated cost, execution time metrics, and severity levels for various SQL queries.
  - Added a new SQL query file demonstrating dynamic filtering and aggregation capabilities for performance analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->