### PR TITLE
Set default value for optimizerSettings parameter

### DIFF
--- a/src/SqlFileAnalyzer.php
+++ b/src/SqlFileAnalyzer.php
@@ -51,7 +51,7 @@ final class SqlFileAnalyzer
         private readonly ExplainAnalyzer $analyzer,
         private readonly string $sqlDir,
         private readonly AIQueryAdvisor $aiAdvisor,
-        OptimizerSettingsInterface|null $optimizerSettings
+        OptimizerSettingsInterface|null $optimizerSettings = null
     ) {
         $this->optimizerSettings = $optimizerSettings ?? new OptimizerSettings($pdo);
     }


### PR DESCRIPTION
Related: #17 

## Sourceryによるサマリー

機能拡張:
- `SqlFileAnalyzer` コンストラクタの `$optimizerSettings` パラメータにデフォルト値を設定しました。値が提供されない場合、提供された PDO インスタンスを使用して `OptimizerSettings` の新しいインスタンスをデフォルトで使用します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set a default value for the `$optimizerSettings` parameter in the `SqlFileAnalyzer` constructor. If no value is provided, it defaults to a new instance of `OptimizerSettings` using the provided PDO instance.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization flexibility by introducing a default value for optional configuration settings. Now, if no specific settings are provided during setup, a default configuration is automatically applied for a smoother and more flexible experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->