### PR TITLE
feat: Gate query execution behind a SQL safety classifier (ND/WD PR1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ sql-quality analyze --sql-dir=sql/ --params=params.php --lang=ja
 | `--output=DIR` | Output directory for markdown reports | |
 | `--lang=LANG` | Language for messages: `en` or `ja` | `en` |
 
+### Execution Safety
+
+The analyzer is conservative about what it runs against your database:
+
+- **Read-only `SELECT` / `WITH ... SELECT`** are fully analyzed: `EXPLAIN FORMAT=JSON`, `EXPLAIN ANALYZE`, and a timing loop that actually executes the query.
+- **DML (`INSERT` / `UPDATE` / `DELETE` / `REPLACE`)** is **never executed**. Only the read-only `EXPLAIN FORMAT=JSON` runs, so issues such as `MultiTableUpdate` are still detected without modifying any data.
+- **Unsafe `SELECT`s** (`FOR UPDATE`, `LOCK IN SHARE MODE`, `INTO OUTFILE`/`DUMPFILE`, `SLEEP()`, `GET_LOCK()`, …) are treated like DML: planned via `EXPLAIN FORMAT=JSON` but not executed.
+- **DDL** and other statements that `EXPLAIN` cannot plan are skipped.
+
+Each query in the JSON output carries an `executed` flag and, when not executed, a `skipped_reason` explaining why:
+
+```json
+"20_multi_table_update.sql": {
+    "executed": false,
+    "skipped_reason": "UPDATE statement: read-only EXPLAIN executed, query not run (no EXPLAIN ANALYZE/timing)",
+    "issues": [ { "type": "MultiTableUpdate", "...": "..." } ]
+}
+```
+
 ## Claude Code Skills
 
 For [Claude Code](https://claude.ai/code) users, automated SQL optimization skills are available:

--- a/bin/sql-quality
+++ b/bin/sql-quality
@@ -256,6 +256,8 @@ USAGE;
             $queries[$sqlFile] = [
                 'cost' => $cost,
                 'execution_time_ms' => ($result['execution_time'] ?? 0) * 1000,
+                'executed' => $result['executed'] ?? true,
+                'skipped_reason' => $result['skipped_reason'] ?? null,
                 'issues' => $issues,
                 'optimizer_impact' => $costReduction !== null ? [
                     'cost_reduction_percent' => round($costReduction, 2),

--- a/src/SqlClassification.php
+++ b/src/SqlClassification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SqlQuality;
+
+/**
+ * Result of classifying a SQL statement for safe analysis.
+ *
+ * - $executable  : whether the query itself may be run (EXPLAIN ANALYZE + timing loop).
+ *                  Only true for read-only SELECT / WITH ... SELECT without unsafe constructs.
+ * - $explainable : whether `EXPLAIN FORMAT=JSON` may be executed. This is read-only and safe
+ *                  for SELECT and DML (INSERT/UPDATE/DELETE/REPLACE) alike, so DML is still
+ *                  statically analyzable without ever running the statement.
+ * - $skippedReason : human readable reason when the statement is not executed (null when executable).
+ *
+ * @psalm-immutable
+ * @psalm-type SqlCategory = 'read_only_select'|'dml'|'unsafe_select'|'ddl'|'other'
+ */
+final class SqlClassification
+{
+    /** @param SqlCategory $category */
+    public function __construct(
+        public readonly string $category,
+        public readonly bool $executable,
+        public readonly bool $explainable,
+        public readonly string|null $skippedReason,
+    ) {
+    }
+}

--- a/src/SqlClassifier.php
+++ b/src/SqlClassifier.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SqlQuality;
+
+use function ctype_alpha;
+use function in_array;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function strtoupper;
+use function trim;
+
+/**
+ * Classifies a SQL statement so the analyzer never executes anything unsafe.
+ *
+ * The classifier works on a normalized copy of the SQL (comments and string/identifier
+ * literals removed). The normalized form is used for classification only; the original
+ * SQL is always what gets sent to the database unchanged.
+ *
+ * @psalm-immutable
+ * @psalm-import-type SqlCategory from SqlClassification
+ */
+final class SqlClassifier
+{
+    private const DML_KEYWORDS = ['INSERT', 'UPDATE', 'DELETE', 'REPLACE'];
+    private const DDL_KEYWORDS = ['CREATE', 'ALTER', 'DROP', 'TRUNCATE', 'RENAME'];
+    private const SELECT_KEYWORDS = ['SELECT', 'TABLE', 'VALUES'];
+    private const CTE_MAIN_KEYWORDS = ['SELECT', 'UPDATE', 'DELETE', 'INSERT', 'REPLACE'];
+
+    /** Constructs that make an otherwise read-only SELECT unsafe to execute. */
+    private const UNSAFE_SELECT_PATTERNS = [
+        'FOR UPDATE' => '/\bFOR\s+UPDATE\b/',
+        'FOR SHARE' => '/\bFOR\s+SHARE\b/',
+        'LOCK IN SHARE MODE' => '/\bLOCK\s+IN\s+SHARE\s+MODE\b/',
+        'INTO OUTFILE' => '/\bINTO\s+OUTFILE\b/',
+        'INTO DUMPFILE' => '/\bINTO\s+DUMPFILE\b/',
+        'SLEEP()' => '/\bSLEEP\s*\(/',
+        'GET_LOCK()' => '/\bGET_LOCK\s*\(/',
+        'RELEASE_LOCK()' => '/\bRELEASE_LOCK\s*\(/',
+        'BENCHMARK()' => '/\bBENCHMARK\s*\(/',
+    ];
+
+    public function classify(string $sql): SqlClassification
+    {
+        $normalized = $this->normalize($sql);
+        if ($normalized === '') {
+            return new SqlClassification('other', false, false, 'Empty statement; not analyzed');
+        }
+
+        $keyword = $this->mainStatementKeyword($normalized);
+
+        if (in_array($keyword, self::DML_KEYWORDS, true)) {
+            return new SqlClassification(
+                'dml',
+                false,
+                true,
+                sprintf('%s statement: read-only EXPLAIN executed, query not run (no EXPLAIN ANALYZE/timing)', $keyword),
+            );
+        }
+
+        if (in_array($keyword, self::DDL_KEYWORDS, true)) {
+            return new SqlClassification(
+                'ddl',
+                false,
+                false,
+                sprintf('%s statement: not analyzed (DDL is not supported by EXPLAIN)', $keyword),
+            );
+        }
+
+        if (in_array($keyword, self::SELECT_KEYWORDS, true)) {
+            $unsafe = $this->findUnsafeConstruct($normalized);
+            if ($unsafe !== null) {
+                return new SqlClassification(
+                    'unsafe_select',
+                    false,
+                    true,
+                    sprintf('Unsafe SELECT (%s): read-only EXPLAIN executed, query not run', $unsafe),
+                );
+            }
+
+            return new SqlClassification('read_only_select', true, true, null);
+        }
+
+        return new SqlClassification(
+            'other',
+            false,
+            false,
+            sprintf('%s statement: not analyzed', $keyword === '' ? 'Unknown' : $keyword),
+        );
+    }
+
+    /** Returns the upper-cased leading keyword, resolving a leading WITH (CTE) to the main statement. */
+    private function mainStatementKeyword(string $normalized): string
+    {
+        if (preg_match('/^[^A-Za-z]*([A-Za-z]+)/', $normalized, $matches) !== 1) {
+            return '';
+        }
+
+        $first = strtoupper($matches[1]);
+        if ($first !== 'WITH') {
+            return $first;
+        }
+
+        return $this->resolveCteMainKeyword(strtoupper($normalized));
+    }
+
+    /**
+     * Finds the main statement keyword that follows the CTE definitions of a WITH clause.
+     * CTE bodies live inside parentheses, so the first top-level (depth 0) statement keyword wins.
+     *
+     * @psalm-pure
+     */
+    private function resolveCteMainKeyword(string $upper): string
+    {
+        $length = strlen($upper);
+        $depth = 0;
+        $token = '';
+        for ($i = 0; $i < $length; $i++) {
+            $char = $upper[$i];
+            if ($char === '(') {
+                $depth++;
+                $token = '';
+                continue;
+            }
+
+            if ($char === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+
+                $token = '';
+                continue;
+            }
+
+            if (ctype_alpha($char)) {
+                $token .= $char;
+                continue;
+            }
+
+            if ($depth === 0 && in_array($token, self::CTE_MAIN_KEYWORDS, true)) {
+                return $token;
+            }
+
+            $token = '';
+        }
+
+        if ($depth === 0 && in_array($token, self::CTE_MAIN_KEYWORDS, true)) {
+            return $token;
+        }
+
+        return 'SELECT';
+    }
+
+    /** @psalm-pure */
+    private function findUnsafeConstruct(string $normalized): string|null
+    {
+        $upper = strtoupper($normalized);
+        foreach (self::UNSAFE_SELECT_PATTERNS as $label => $pattern) {
+            if (preg_match($pattern, $upper) === 1) {
+                return $label;
+            }
+        }
+
+        return null;
+    }
+
+    /** Removes comments and string/identifier literals so classification never trips on their contents. */
+    private function normalize(string $sql): string
+    {
+        $length = strlen($sql);
+        $out = '';
+        $i = 0;
+        while ($i < $length) {
+            $char = $sql[$i];
+            $next = $i + 1 < $length ? $sql[$i + 1] : '';
+
+            if ($char === '-' && $next === '-') {
+                $i = $this->skipToEndOfLine($sql, $i + 2, $length);
+                $out .= ' ';
+                continue;
+            }
+
+            if ($char === '#') {
+                $i = $this->skipToEndOfLine($sql, $i + 1, $length);
+                $out .= ' ';
+                continue;
+            }
+
+            if ($char === '/' && $next === '*') {
+                $i = $this->skipBlockComment($sql, $i + 2, $length);
+                $out .= ' ';
+                continue;
+            }
+
+            if ($char === "'" || $char === '"' || $char === '`') {
+                $i = $this->skipQuoted($sql, $i + 1, $char, $length);
+                $out .= ' ';
+                continue;
+            }
+
+            $out .= $char;
+            $i++;
+        }
+
+        return trim($out);
+    }
+
+    /** @psalm-pure */
+    private function skipToEndOfLine(string $sql, int $i, int $length): int
+    {
+        while ($i < $length && $sql[$i] !== "\n") {
+            $i++;
+        }
+
+        return $i;
+    }
+
+    /** @psalm-pure */
+    private function skipBlockComment(string $sql, int $i, int $length): int
+    {
+        while ($i < $length && ! ($sql[$i] === '*' && $i + 1 < $length && $sql[$i + 1] === '/')) {
+            $i++;
+        }
+
+        return $i + 2;
+    }
+
+    /** @psalm-pure */
+    private function skipQuoted(string $sql, int $i, string $quote, int $length): int
+    {
+        while ($i < $length) {
+            $char = $sql[$i];
+            if ($char === '\\' && $quote !== '`') {
+                $i += 2;
+                continue;
+            }
+
+            if ($char === $quote) {
+                if ($i + 1 < $length && $sql[$i + 1] === $quote) {
+                    $i += 2;
+                    continue;
+                }
+
+                return $i + 1;
+            }
+
+            $i++;
+        }
+
+        return $i;
+    }
+}

--- a/src/SqlFileAnalyzer.php
+++ b/src/SqlFileAnalyzer.php
@@ -36,7 +36,6 @@ use const PATHINFO_FILENAME;
 /**
  * @psalm-import-type SqlParams from Types
  * @psalm-import-type ExplainResult from Types
- * @psalm-import-type ExplainWithSql from Types
  * @psalm-import-type AnalysisResult from Types
  * @psalm-import-type AnalysisWithSettingsResult from Types
  * @psalm-import-type DetectedWarning from Types
@@ -47,15 +46,18 @@ final class SqlFileAnalyzer
 {
     private const TRIAL_COUNT = 10;
     private readonly OptimizerSettingsInterface $optimizerSettings;
+    private readonly SqlClassifier $classifier;
 
     public function __construct(
         private readonly PDO $pdo,
         private readonly ExplainAnalyzer $analyzer,
         private readonly string $sqlDir,
         private readonly AIQueryAdvisor $aiAdvisor,
-        OptimizerSettingsInterface|null $optimizerSettings = null
+        OptimizerSettingsInterface|null $optimizerSettings = null,
+        SqlClassifier|null $classifier = null
     ) {
         $this->optimizerSettings = $optimizerSettings ?? new OptimizerSettings($pdo);
+        $this->classifier = $classifier ?? new SqlClassifier();
     }
 
     /**
@@ -152,17 +154,18 @@ final class SqlFileAnalyzer
     }
 
     /**
+     * Executes `EXPLAIN FORMAT=JSON`, which is read-only and safe for both SELECT and DML.
+     *
      * @param array<string, mixed> $params
      *
-     * @return ExplainWithSql
+     * @return ExplainResult
      *
      * @throws RuntimeException
      */
-    private function executeExplain(string $sql, array $params): array
+    private function executeExplainJson(string $sql, array $params): array
     {
         $interpolatedSql = $this->interpolateQuery($sql, $params);
 
-        // FORMAT=JSON の EXPLAIN を実行
         $stmt = $this->pdo->query('EXPLAIN FORMAT=JSON ' . $interpolatedSql);
         if ($stmt === false) {
             throw new RuntimeException('Failed to execute EXPLAIN query');
@@ -179,9 +182,23 @@ final class SqlFileAnalyzer
             throw new RuntimeException('Empty EXPLAIN result');
         }
 
+        /** @var ExplainResult $explainJsonData */
         $explainJsonData = json_decode($explainJson, true);
 
-        // EXPLAIN ANALYZE を実行
+        return $explainJsonData;
+    }
+
+    /**
+     * Executes `EXPLAIN ANALYZE`, which actually runs the query. Only call for executable statements.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @throws RuntimeException
+     */
+    private function executeExplainAnalyze(string $sql, array $params): string
+    {
+        $interpolatedSql = $this->interpolateQuery($sql, $params);
+
         $analyzeStmt = $this->pdo->query('EXPLAIN ANALYZE ' . $interpolatedSql);
         if ($analyzeStmt === false) {
             throw new RuntimeException('Failed to execute EXPLAIN ANALYZE query');
@@ -193,7 +210,7 @@ final class SqlFileAnalyzer
             throw new RuntimeException('Failed to get EXPLAIN ANALYZE result');
         }
 
-        return [$explainJsonData, $analyzeResult[0]];
+        return (string) $analyzeResult[0];
     }
 
     /**
@@ -295,14 +312,23 @@ final class SqlFileAnalyzer
     ): array {
         $sql = $this->readSqlFile($sqlFile);
 
-        // デフォルト（オプティマイザーあり）の分析を実行
-        $defaultAnalysis = $this->analyzeWithSettings($sql, $params, $sqlFile, $outputDir);
+        // SQL を分類し、EXPLAIN すら実行できない文（DDL など）は早期にスキップする
+        $classification = $this->classifier->classify($sql);
+        if (! $classification->explainable) {
+            throw new RuntimeException($classification->skippedReason ?? 'Statement is not analyzable');
+        }
 
-        // オプティマイザーを無効化して分析
+        // デフォルト（オプティマイザーあり）の分析を実行
+        $defaultAnalysis = $this->analyzeWithSettings($sql, $params, $sqlFile, $outputDir, $classification);
+
+        // オプティマイザーを無効化して分析。例外が出ても optimizer_switch を必ず復元する
         $savedSettings = $this->optimizerSettings->saveCurrentSettings();
         $this->optimizerSettings->disableAll();
-        $noOptimizerAnalysis = $this->analyzeWithSettings($sql, $params, $sqlFile, $outputDir);
-        $this->optimizerSettings->restore($savedSettings);
+        try {
+            $noOptimizerAnalysis = $this->analyzeWithSettings($sql, $params, $sqlFile, $outputDir, $classification);
+        } finally {
+            $this->optimizerSettings->restore($savedSettings);
+        }
 
         // 両方の結果を含めて返す
         $noOptimizerAnalysisCost = $noOptimizerAnalysis['cost'];
@@ -331,11 +357,21 @@ final class SqlFileAnalyzer
         string $sql,
         array $params,
         string $sqlFile,
-        string $outputDir
+        string $outputDir,
+        SqlClassification $classification
     ): array {
-        $executionTime = $this->getExecutedTime($sql, $params);
-        /** @var ExplainResult $explainResult */
-        [$explainResult, $explainAnalyze] = $this->executeExplain($sql, $params);
+        // EXPLAIN FORMAT=JSON は読み取り専用なので SELECT/DML を問わず安全に実行できる
+        $explainResult = $this->executeExplainJson($sql, $params);
+
+        // 実際にクエリを走らせる処理（計測ループ・EXPLAIN ANALYZE）は安全な SELECT のみに限定する
+        if ($classification->executable) {
+            $executionTime = $this->getExecutedTime($sql, $params);
+            $explainAnalyze = $this->executeExplainAnalyze($sql, $params);
+        } else {
+            $executionTime = 0.0;
+            $explainAnalyze = '-- Skipped: ' . ($classification->skippedReason ?? 'query not executed');
+        }
+
         /** @var list<array{Level: string, Code: int, Message: string}> $warnings */
         $warnings = $this->getWarnings();
         /** @var list<DetectedWarning> $issues */
@@ -362,6 +398,8 @@ final class SqlFileAnalyzer
             'ai_suggestions' => $aiPrompt,
             'cost' => $cost,
             'execution_time' => $executionTime,
+            'executed' => $classification->executable,
+            'skipped_reason' => $classification->skippedReason,
         ];
     }
 

--- a/src/Types.php
+++ b/src/Types.php
@@ -144,6 +144,8 @@ namespace Koriym\SqlQuality;
  *   ai_suggestions: string,
  *   cost: float,
  *   execution_time: float,
+ *   executed: bool,
+ *   skipped_reason: string|null,
  *   optimizer_comparison: array{
  *      with_optimizer: array<array-key, mixed>,
  *      without_optimizer: array<array-key, mixed>,
@@ -222,7 +224,9 @@ namespace Koriym\SqlQuality;
  *   explain_result: ExplainResult,
  *   ai_suggestions: string,
  *   cost: float,
- *   execution_time: float
+ *   execution_time: float,
+ *   executed: bool,
+ *   skipped_reason: string|null
  * }
  */
 final class Types

--- a/tests/SqlClassifierTest.php
+++ b/tests/SqlClassifierTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SqlQuality;
+
+use PHPUnit\Framework\TestCase;
+
+class SqlClassifierTest extends TestCase
+{
+    private SqlClassifier $classifier;
+
+    protected function setUp(): void
+    {
+        $this->classifier = new SqlClassifier();
+    }
+
+    /** @return array<string, array{string, string, bool, bool}> */
+    public function classificationProvider(): array
+    {
+        return [
+            // sql, expected category, executable, explainable
+            'simple select' => ['SELECT * FROM users', 'read_only_select', true, true],
+            'select with leading comment' => ["-- a comment\nSELECT 1", 'read_only_select', true, true],
+            'with select cte' => ['WITH active AS (SELECT id FROM users WHERE status = \'active\') SELECT * FROM active', 'read_only_select', true, true],
+            'parenthesised union select' => ['(SELECT 1) UNION (SELECT 2)', 'read_only_select', true, true],
+            'string literal mentioning for update is safe' => ["SELECT * FROM posts WHERE note = 'please FOR UPDATE now'", 'read_only_select', true, true],
+            'comment mentioning update is safe' => ["-- UPDATE posts later\nSELECT id FROM posts", 'read_only_select', true, true],
+
+            'update' => ['UPDATE posts SET view_count = view_count + 1 WHERE id = 1', 'dml', false, true],
+            'multi table update' => ['UPDATE posts p JOIN comments c ON p.id = c.post_id SET p.view_count = 1', 'dml', false, true],
+            'delete' => ['DELETE FROM posts WHERE id = 1', 'dml', false, true],
+            'insert' => ['INSERT INTO posts (id) VALUES (1)', 'dml', false, true],
+            'replace' => ['REPLACE INTO posts (id) VALUES (1)', 'dml', false, true],
+            'with update cte' => ['WITH c AS (SELECT id FROM posts) UPDATE posts SET view_count = 0 WHERE id IN (SELECT id FROM c)', 'dml', false, true],
+
+            'create table' => ['CREATE TABLE t (id INT PRIMARY KEY)', 'ddl', false, false],
+            'drop table' => ['DROP TABLE posts', 'ddl', false, false],
+            'alter table' => ['ALTER TABLE posts ADD COLUMN x INT', 'ddl', false, false],
+            'truncate' => ['TRUNCATE TABLE posts', 'ddl', false, false],
+
+            'select for update' => ['SELECT * FROM posts WHERE id = 1 FOR UPDATE', 'unsafe_select', false, true],
+            'select lock in share mode' => ['SELECT * FROM posts LOCK IN SHARE MODE', 'unsafe_select', false, true],
+            'select into outfile' => ["SELECT * FROM posts INTO OUTFILE '/tmp/x.txt'", 'unsafe_select', false, true],
+            'select sleep' => ['SELECT SLEEP(5)', 'unsafe_select', false, true],
+            'select get_lock' => ["SELECT GET_LOCK('x', 10)", 'unsafe_select', false, true],
+
+            'call procedure' => ['CALL my_proc(1)', 'other', false, false],
+            'set statement' => ["SET optimizer_switch = 'index_merge=off'", 'other', false, false],
+            'empty statement' => ['', 'other', false, false],
+            'comment only' => ['-- nothing here', 'other', false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider classificationProvider
+     * @test
+     */
+    public function classify(string $sql, string $category, bool $executable, bool $explainable): void
+    {
+        $result = $this->classifier->classify($sql);
+
+        $this->assertSame($category, $result->category, $sql);
+        $this->assertSame($executable, $result->executable, $sql);
+        $this->assertSame($explainable, $result->explainable, $sql);
+
+        if ($executable) {
+            $this->assertNull($result->skippedReason);
+
+            return;
+        }
+
+        $this->assertNotNull($result->skippedReason);
+    }
+}


### PR DESCRIPTION
## Summary

This is **PR1 of the ND/WD two-mode plan** — the safety foundation, kept deliberately small and low-risk. It does **not** add the `--mode=nd|wd` flag, the DDL parser, or the unified EXPLAIN walker yet; those are follow-up PRs. The goal here is to stop the analyzer from ever executing anything unsafe, and to fix a real bug discovered while evaluating the plan.

### Why

The current analyzer executes whatever SQL it is handed. `getExecutedTime()` runs the interpolated query up to **12 times** (2 warm-ups + 10 timed) via `PDO::query()`, with no SELECT/DML distinction. Because `20_multi_table_update.sql` is in the fixtures, the tool was effectively running `UPDATE`s against the target database during analysis. This PR closes that gap.

### What changed

- **New `SqlClassifier` + `SqlClassification`** — classify each statement and decide what is allowed to run:
  - **Read-only `SELECT` / `WITH ... SELECT`** (no unsafe constructs) → fully analyzed (`EXPLAIN FORMAT=JSON` + `EXPLAIN ANALYZE` + timing loop). Unchanged behavior.
  - **DML** (`INSERT`/`UPDATE`/`DELETE`/`REPLACE`) → planned with the **read-only** `EXPLAIN FORMAT=JSON` only; never executed. `MultiTableUpdate` and other EXPLAIN-based detections still work.
  - **Unsafe `SELECT`** (`FOR UPDATE`, `LOCK IN SHARE MODE`, `INTO OUTFILE`/`DUMPFILE`, `SLEEP()`, `GET_LOCK()`, …) → treated like DML: planned, not executed.
  - **DDL / other** → skipped cleanly.
  - Classification runs on a normalized copy (comments + string/identifier literals stripped) so it never trips on literal contents; the original SQL is always what reaches the DB.
- **`EXPLAIN FORMAT=JSON` vs execution split** — `executeExplain()` is split into `executeExplainJson()` (read-only, always safe) and `executeExplainAnalyze()` (executes, gated). This is the key refinement over a naive "DML → static-only" approach: `EXPLAIN FORMAT=JSON` is read-only even for DML, so we keep WD-quality plan detection for DML without running it.
- **`try/finally` around optimizer restore** — fixes an existing latent bug: if analysis threw between `disableAll()` and `restore()`, the disabled `optimizer_switch` leaked onto the connection.
- **New output fields** — `executed: bool` and `skipped_reason: string|null` added to the analysis result, the `AnalysisResult` / `AnalysisWithSettingsResult` psalm types, and the CLI JSON `queries[*]`.
- **README** — new "Execution Safety" section documenting the behavior and the new JSON fields.

### Behavior change to call out

This is **not** fully backward compatible by design: DML statements that were previously executed/timed are now planned-only (`executed: false`). That is the intended fix.

## Test plan

- New `SqlClassifierTest` (DB-independent) covers SELECT, leading-comment SELECT, WITH-SELECT, parenthesized UNION, string/comment literals that mention `FOR UPDATE`/`UPDATE` (must stay safe), UPDATE/DELETE/INSERT/REPLACE, WITH-UPDATE CTE, CREATE/DROP/ALTER/TRUNCATE, `FOR UPDATE` / `LOCK IN SHARE MODE` / `INTO OUTFILE` / `SLEEP` / `GET_LOCK`, CALL, SET, empty, and comment-only input.
- `composer test` → 34 tests / 109 assertions pass.
- `composer cs` (phpcs PSR12 + Doctrine) → clean.
- Psalm → unchanged at the pre-existing baseline (62 errors); **zero** new errors introduced by the new/changed files (`SqlClassifier` marked `@psalm-immutable`, pure helpers annotated `@psalm-pure`, `SqlClassification` marked `@psalm-immutable`).

## Follow-ups (not in this PR)

- PR2: unified EXPLAIN walker + migrate detectors behind a compat wrapper; add `severity`/`confidence`/`evidence`.
- PR3: `--mode=nd` with purely syntactic detectors (no schema needed).
- PR4: schema-aware ND via a DDL parser (highest risk; `tests/sql/schema.sql` as baseline fixture, graceful degradation).

https://claude.ai/code/session_01SAFFmoSKojkSFw8mPAVTcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAFFmoSKojkSFw8mPAVTcz)_